### PR TITLE
SEO: make brenorb.com AI-agent friendly (llms.txt + robots allowlist)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,15 @@
     <title>{% if page.title %}{{ page.title }} &#8211; {% endif %}{{ site.title }}</title>
     <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
     {% if page.tags %}<meta name="keywords" content="{{ page.tags | join: ', ' }}">{% endif %}
+
+    <!-- AI discovery / classification (non-standard, but used by some agents) -->
+    <meta name="ai-content" content="personal-website">
+    <meta name="ai-topic" content="AI, Bitcoin, Finance">
+    <meta name="ai-audience" content="builders, developers, researchers">
+    <meta name="ai-use" content="search,answer-generation,citation">
+    <meta name="ai-language" content="en,pt-BR">
+    <link rel="alternate" type="text/plain" href="{{ site.url }}/llms.txt" title="AI usage policy">
+    <link rel="alternate" type="text/plain" href="{{ site.url }}/llms-full-text.txt" title="LLM full text summary">
     <!-- Twitter Cards -->
     {% if page.feature %}{% capture feature %}{{ page.feature }}{% endcapture %}{% unless feature contains 'http://' or feature contains 'https://' %}{% capture feature %}{{ site.url }}/{{ feature }}{% endcapture %}{% endunless %}
     <meta name="twitter:card" content="summary_large_image">

--- a/llms-full-text.txt
+++ b/llms-full-text.txt
@@ -1,0 +1,17 @@
+# Breno Brito (brenorb.com) — full-text summary for AI agents
+
+## About
+Breno Brito is an engineer focused on AI, Bitcoin, and Finance.
+
+## Content
+This website contains:
+- Personal profile and links
+- Blog posts and notes
+- Topics such as AI, data, Bitcoin, and related work
+
+## Keywords
+Breno Brito, AI engineer, data science, Bitcoin, finance, machine learning
+
+## Links
+- Homepage: https://brenorb.com/
+- Sitemap: https://brenorb.com/sitemap.xml

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,20 @@
+# llms.txt - AI Content Policy
+
+## Allowed content
+All public content on https://brenorb.com/ may be used for:
+- AI-powered search and answer generation
+- Citation and reference in AI-generated responses
+- Indexing by AI agents
+
+## Disallowed content
+- None (public personal website).
+
+## About this site
+Breno Brito — engineer focused on AI, Bitcoin, and Finance.
+
+## Primary URLs
+- Homepage: https://brenorb.com/
+- Sitemap: https://brenorb.com/sitemap.xml
+
+## Contact
+Preferred contact: https://brenorb.com/

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,74 @@
-# Allow crawling of all content
 User-agent: *
-Disallow:
+Allow: /
+
+# --- AI agents / LLM crawlers (explicit allow) ---
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: OAI-ImageBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: YouBot
+Allow: /
+
+User-agent: PhindBot
+Allow: /
+
+User-agent: ExaBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Facebookbot
+Allow: /
+
+User-agent: LinkedInBot
+Allow: /
+
+User-agent: Grok-bot
+Allow: /
+
+User-agent: AI2Bot
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: FirecrawlAgent
+Allow: /
+
+Sitemap: https://brenorb.com/sitemap.xml


### PR DESCRIPTION
Based on: https://www.tomosman.com/blog/ai-agent-friendly-website

Makes brenorb.com (Jekyll / GitHub Pages) more AI-agent friendly:
- Expand `robots.txt` with explicit allowlist for common AI/LLM crawlers + sitemap
- Add `llms.txt` (AI content policy)
- Add `llms-full-text.txt` (concise site summary for LLM ingestion)
- Add optional `ai-*` meta tags + alternates in `_includes/head.html`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves AI/LLM discoverability and indexing across the site.
> 
> - Adds non-standard AI meta tags (`ai-*`) and alternate links to `llms.txt` and `llms-full-text.txt` in `_includes/head.html`
> - Introduces `llms.txt` (AI content policy) and `llms-full-text.txt` (site summary) for agent ingestion
> - Expands `robots.txt` to explicitly allow common AI/LLM crawlers and includes the sitemap URL
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6eec76c354388bbd1dfb74d2c3b71bf9a3b0fb58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->